### PR TITLE
銀行に管理画面を追加。

### DIFF
--- a/src/Eard/Form/BankForm.php
+++ b/src/Eard/Form/BankForm.php
@@ -223,6 +223,7 @@ class BankForm extends FormBase {
 							'type' => "input",
 							'text' =>
 									"\n".
+									"§f1000μ単位での借り入れが可能です。\n".
 									"§fご希望の金額を入力してください。\n".
 									"\n",
 									'placeholder' => "お借入れ額 (μ)"
@@ -245,6 +246,15 @@ class BankForm extends FormBase {
 				$this->sendErrorModal(
 					"銀行 > お借入れ",
 					"フォームには半角数字以外入力できません。", 1
+				);
+				break;
+			}
+
+			//1000μ単位であるか
+			if($amount % 1000 != 0){
+				$this->sendErrorModal(
+					"銀行 > お借入れ",
+					"フォームには1000μ単位で入力してください。", 1
 				);
 				break;
 			}
@@ -401,10 +411,14 @@ class BankForm extends FormBase {
 			break;
 			case 15:
 			$debit = $this->lists;
+			//分割初回の場合 -> 金利含む合計 , そうでない -> 残りの返済額合計
 			$total = ($debit[3] == 5) ? $debit[0] * (1 + $debit[2]) : $debit[4];
+			//除算した余りを計算
 			$remainder =  $total % $debit[3];
+			//余りを除いた計算
 			$per_time = round (($total - $remainder) / $debit[3]);
-			$first_time = ($remainder > 1) ? round($per_time + $remainder) : 0;
+			//余りが0より大きい場合 -> そのまま合計 ,  そうでない -> 0 (false)
+			$first_time = ($remainder > 0) ? round($per_time + $remainder) : 0;
 
 			if($first_time){
 				$buttons[] = ['text' => "初回 {$first_time}μ"];

--- a/src/Eard/Form/BankForm.php
+++ b/src/Eard/Form/BankForm.php
@@ -22,27 +22,27 @@ class BankForm extends FormBase {
 			$this->close();
 		}
 
-		if(!$account){
-			$data = [
-				'type'    => "modal",
-				'title'   => "銀行 > お預入れ",
-				'content' => "§f銀行口座がまだ開設されていないようです。\n".
-							"新たに口座を開設しますか？\n".
-							"\n".
-							"【条件】\n".
-							"§fデポジット: §7500μ 以上\n".
-							"§f生活ライセンス: §7一般 以上\n".
-							"§f滞在時間:§7 2時間 以上\n".
-							"\n",
-				'button1' => "はい",
-				'button2' => "いいえ",
-			];
-			$cache = [3, 0];
-			break;
-		}
-
 		switch($id){
 			case 1:
+				if(!$account){
+					$data = [
+						'type'    => "modal",
+						'title'   => "銀行 > お預入れ",
+						'content' =>
+								"§f銀行口座がまだ開設されていないようです。\n".
+								"新たに口座を開設しますか？\n".
+								"\n".
+								"【条件】\n".
+								"§fデポジット: §7500μ 以上\n".
+								"§f生活ライセンス: §7一般 以上\n".
+								"§f滞在時間:§7 2時間 以上\n".
+								"\n",
+							'button1' => "はい",
+							'button2' => "いいえ",
+						];
+						$cache = [3, 0];
+						break;
+					}
 				// メニュー一覧
 				$buttons = [
 					['text' => "お預入れ"],
@@ -53,10 +53,13 @@ class BankForm extends FormBase {
 				];
 				$cache = [2, 6, 8, 12, 17];
 
+				$balance = $bank->getBalance($playerData);//残高を確認
 				$data = [
 					'type'    => "form",
 					'title'   => "銀行",
-					'content' => "§fご希望のお取引を選択してください。\n",
+					'content' =>
+								"§fご希望のお取引を選択してください。\n".
+								"§f現在の残高は §2{$balance}μ §fです。\n",
 					'buttons' => $buttons
 				];
 			break;
@@ -113,7 +116,7 @@ class BankForm extends FormBase {
 					'title'   => "銀行 > 新規口座開設",
 					'content' =>
 						"\n§f{$playerData->getName()}さんの口座が開設されました。\n".
-						"現在の残金は{$amount}μです。",
+						"現在の残高は {$amount}μ です。",
 					'buttons' => [
 						['text' => '戻る']
 					]
@@ -147,7 +150,8 @@ class BankForm extends FormBase {
 						'type'    => "form",
 						'title'   => "銀行 > お預入れ",
 						'content' =>
-							"\n§f{$amount}μが預金されました。\n",
+							"\n§f{$amount}μが預金されました。\n".
+							"詳細は「通帳」でご確認ください。",
 						'buttons' => [
 							['text' => '戻る']
 						]
@@ -194,7 +198,8 @@ class BankForm extends FormBase {
 					'type'    => "form",
 					'title'   => "銀行 > お引き出し",
 					'content' =>
-						"\n§f{$amount}μが引き出されました。\n",
+						"\n§f{$amount}μ が引き出されました。\n".
+						"詳細は「通帳」でご確認ください。",
 					'buttons' => [
 						['text' => '戻る']
 					]
@@ -415,7 +420,9 @@ class BankForm extends FormBase {
 			$data = [
 				'type'    => "form",
 				'title'   => "銀行 > ご返済 > 分割払い",
-				'content' => "§fここでは分割払い(5回払い)ができます\n",
+				'content' =>
+						"§fここでは分割払い(5回払い)ができます\n".
+						"※選択するとすぐに返済が始まります。ご注意ください。",
 				'buttons' => $buttons
 			];
 			break;
@@ -452,7 +459,7 @@ class BankForm extends FormBase {
 				];
 				$cache = [1];
 			break;
-		}
+	}
 
 		// みせる
 		if($cache){

--- a/src/Eard/Form/BankForm.php
+++ b/src/Eard/Form/BankForm.php
@@ -53,7 +53,8 @@ class BankForm extends FormBase {
 				];
 				$cache = [2, 6, 8, 12, 17];
 
-				$balance = $bank->getBalance($playerData);//残高を確認
+				$balance = $account->getMeu()->getAmount();//残高を確認
+				
 				$data = [
 					'type'    => "form",
 					'title'   => "銀行",

--- a/src/Eard/Main.php
+++ b/src/Eard/Main.php
@@ -108,6 +108,7 @@ class Main extends PluginBase implements Listener, CommandExecutor{
 
 		# Eard関連
 		Government::save();
+		Bank::save();
 		BlockObjectManager::saveAllObjects();
 		BlockObjectManager::save();
 		Account::save();

--- a/src/Eard/MeuHandler/Bank.php
+++ b/src/Eard/MeuHandler/Bank.php
@@ -1,6 +1,9 @@
 <?php
 namespace Eard\MeuHandler;
 
+# Basic
+use pocketmine\utils\MainLogger;
+
 #Eard
 use Eard\DBCommunication\DB;
 use Eard\MeuHandler\Account;
@@ -70,12 +73,14 @@ class Bank {
 					$amount = $data[3];//実質負担（金利つき）
 
 					$balance = self::getBalance($playerData);//銀行預金残高
+					$name = $playerData->getName();//名前
 
 					//なるべく返済を促す
 					//銀行預金が十分あれば、それを返済に回す。
 					if($amount <= $balance){
 						$data_1 = self::getRepayData($data, $row['balance']);
 						self::repay($playerData, $row['balance'], 0, $data_1);
+						MainLogger::getLogger()->notice("§aBank: {$name}さんの返済処理(銀行預金から)");
 						return true;
 					}
 
@@ -88,6 +93,7 @@ class Bank {
 						self::writeUp($playerData);
 						self::returnLoan($playerData, $amount);
 						self::incomeToGovernment($playerData, $data[4]);
+						MainLogger::getLogger()->notice("§aBank: {$name}さんの返済処理(所持金から)");
 						return true;
 					}
 
@@ -101,6 +107,7 @@ class Bank {
 						}
 						self::writeUp($playerData);
 						self::incomeToGovernment($playerData, $data[4]);//金利分を政府に
+						MainLogger::getLogger()->notice("§aBank: {$name}さんの返済処理(銀行預金と所持金から)");
 						return true;
 					}
 
@@ -116,6 +123,7 @@ class Bank {
 					$amount = $amount - $data[4];//金利分を除く
 					//延長用のデータ
 					$data_2 = self::getData(0, $amount);//最新の金利が付与されることに注意
+					MainLogger::getLogger()->notice("§aBank: {$name}さんの返済期限を猶予");
 					return self::updateData($playerData, $data_2);
 				}
 			}
@@ -304,7 +312,7 @@ class Bank {
 	*/
 	public static function getData(int $n, int $amount, int $type = 1){
 		switch($n){
-			case 0: $date = strtotime( "+1 second" ); break;
+			case 0: $date = strtotime( "-1 week" ); break;
 			case 1: $date = strtotime( "+1 month" ); break;
 			case 2: $date = strtotime( "+2 month" ); break;
 		}

--- a/src/Eard/MeuHandler/Bank.php
+++ b/src/Eard/MeuHandler/Bank.php
@@ -170,6 +170,11 @@ class Bank {
 	public static function canLend(Account $playerData, int $amount): bool{
 		$player = $playerData->getPlayer();
 
+		//1000μ単位か
+		if($amount % 1000 != 0){
+			return false;
+		}
+
 		// 普通預金口座が存在しているか
 		if(!self::existBankAccount($playerData)){
 			if($player){// オンラインだったら
@@ -299,7 +304,7 @@ class Bank {
 	*/
 	public static function getData(int $n, int $amount, int $type = 1){
 		switch($n){
-			case 0: $date = strtotime( "+1 week" ); break;
+			case 0: $date = strtotime( "+1 second" ); break;
 			case 1: $date = strtotime( "+1 month" ); break;
 			case 2: $date = strtotime( "+2 month" ); break;
 		}
@@ -776,8 +781,10 @@ class Bank {
 	private static $instance = null;
 	private static $account;
 
-	public static $ratio = 0.013;//預金準備率
-	public static $rates = [0.05, 0.08, 0.1];//政策金利
+	//預金準備率
+	public static $ratio = 0.013;
+	//政策金利 [0] 1週間, [1] 1か月, [2] 2か月
+	public static $rates = [0.05, 0.08, 0.1];
 }
 
 


### PR DESCRIPTION
金額をわかりやすくするために借り入れを1000μ単位にしました。
また、政府関係者の方には「金融政策」というボタンが追加され、銀行を管理できるようになります。
「法定準備率操作」では、この率を上下することで、銀行の貸し出し能力を操作できます。
「政策金利」では、借り入れの際の金利を直接決定できます。
「中央銀行当座預金残高操作」では、この残高を増やすことにより、銀行の貸し出し能力が大きくすることが可能となっています。